### PR TITLE
env: do not use the builtin FileType factory for -r

### DIFF
--- a/se/env.py
+++ b/se/env.py
@@ -67,7 +67,7 @@ def getArgs():
     parser.add_argument("-n", dest="interface", type=netifaces.ifaddresses, help="run DHCP and DNS network services on the specified interface")
     parser.add_argument("-o", dest="outfile", default="stdout", help="write performance data to the specified file in JSON format (default: stdout)")
     parser.add_argument("-p", dest="ports", type=validated_ports, default=[22222, 22221, 80], help="ports to listen on in network mode")
-    parser.add_argument("-r", dest="record", type=argparse.FileType('w'), help="file to record all incoming and outgoing messages to")
+    parser.add_argument("-r", dest="record", help="file to record all incoming and outgoing messages to")
     parser.add_argument("-s", dest="slaves", type=validated_slaves, default=[], help="comma delimited list of SolarEdge slave inverter IDs")
     parser.add_argument("-t", dest="type", choices=["2","4","n"], help="serial data source type (2=RS232, 4=RS485, n=network)")
     parser.add_argument("-u", dest="updatefile", type=argparse.FileType('w'), help="file to write firmware update to (experimental)")


### PR DESCRIPTION
When using the -r (record) parameter to semonitor we currently
get a nice traceback:
Traceback (most recent call last):
  File "./semonitor.py", line 227, in <module>
    recFile = se.files.openOutFile(args.record, "a" if args.append else "w")
  File "/home/oliver/solaredge/se/files.py", line 72, in openOutFile
    return open(fileName, writeMode)
TypeError: coercing to Unicode: need string or buffer, file found

This is caused by the fact that we now use the builtin factory FileType
of argparse which now passes a file descriptor rather then the previous
string to openOutFile.

Since we want to either append or write the output/record files and
since we cannot change the file mode once it has been opened,
we thus cannot use the built in factory anymore and revert to the
old behavior of manually calling 'open' to open an output file.

Fixes #76

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>