### PR TITLE
semonitor: properly initialize eof

### DIFF
--- a/semonitor.py
+++ b/semonitor.py
@@ -41,6 +41,7 @@ def terminate(code=0, msg=""):
 
 # process the input data
 def readData(args, mode, dataFile, recFile, outFile, keyStr):
+    eof = False
     updateBuf = list('\x00' * UPDATE_SIZE) if args.updatefile else []
     if mode.passiveMode:
         # skip data until the start of the first complete message


### PR DESCRIPTION
In commit a78d31163b9f8b4 ("Clean up message logic and eof handling")
the eof character was being checked in readData. When master mode
however, this led to an unbound eof variable as loop condiational.

Fixes #78

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>