### PR TITLE
test: Store and compare 'rec' files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
-test/pcap/** filter=lfs diff=lfs merge=lfs -text
-test/json/** filter=lfs diff=lfs merge=lfs -text
 test/csv/** filter=lfs diff=lfs merge=lfs -text
+test/json/** filter=lfs diff=lfs merge=lfs -text
+test/pcap/** filter=lfs diff=lfs merge=lfs -text
+test/rec/** filter=lfs diff=lfs merge=lfs -text

--- a/test/rec/7f104920.rec
+++ b/test/rec/7f104920.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fdd069c7a8ecba17e31f4feeae33552e28cdc18045ebba55572183afaf76e44b
+size 368958

--- a/test/rec/d-tamm-2.rec
+++ b/test/rec/d-tamm-2.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ff1974d378d79ff907e428a36bdc9639be4eb0f190c42a1f93df8841b840502
+size 726488

--- a/test/rec/d-tamm-20160809.rec
+++ b/test/rec/d-tamm-20160809.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e59a0afafa4c80ac1bac568c617da8c21a5803db786856b5fd321672458f4da5
+size 421151

--- a/test/rec/jbuehl-20171119000004.rec
+++ b/test/rec/jbuehl-20171119000004.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63bfa520c78ddcb7b137b18ac81acbf74965deb39e6992a70c8c1b2b9b8fe71b
+size 229112

--- a/test/test.sh
+++ b/test/test.sh
@@ -21,6 +21,7 @@ do
     echo "Key option: ${KEY_OPTION}"
     tshark -r "test/pcap/${SAMPLE}.pcap" -T fields -e data | ./utilities/unhexlify.py | ./semonitor.py -r "${TMP}/${SAMPLE}.rec" -o "${TMP}/${SAMPLE}.json" - $KEY_OPTION
     diff "${TMP}/${SAMPLE}.json" "test/json/${SAMPLE}.json"
+    cmp -l "${TMP}/${SAMPLE}.rec" "test/rec/${SAMPLE}.rec"
     mkdir "${TMPSE2CSV}"
     cat "test/json/${SAMPLE}.json" | conversion/se2csv.py -p "${TMPSE2CSV}/${SAMPLE}" -t
     diff "${TMP}/se2csv" "test/csv/${SAMPLE}/" -w


### PR DESCRIPTION
Semonitor currently outputs rec files but we never test these files.
Add the current rec files as reference and compare these when testing.

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>