### PR TITLE
Write the exact bytes to the record file that were read from the input file.

### DIFF
--- a/se/msg.py
+++ b/se/msg.py
@@ -224,7 +224,7 @@ def sendMsg(dataFile, msg, recFile):
     recordMsg(magic + msg, recFile)
 
 # write a message to the record file
-def recordMsg(msg, recFile);
+def recordMsg(msg, recFile):
     if recFile:
         recFile.write(msg)
         recFile.flush()

--- a/se/msg.py
+++ b/se/msg.py
@@ -84,30 +84,29 @@ checksumLen = 2
 # message debugging sequence numbers
 dataInSeq = 0
 dataOutSeq = 0
-recSeq = 0
 
 # return the next message
 def readMsg(inFile, recFile, mode):
-    global dataInSeq, recSeq
+    global dataInSeq
     dataInSeq += 1
     msg = ""
     eof = False
     if not (mode.passiveMode or (mode.serialType == 4)):
         # active mode that is not rs485
         # read the magic number and header
-        msg = readBytes(inFile, magicLen + msgHdrLen, mode)
+        msg = readBytes(inFile, recFile, magicLen + msgHdrLen, mode)
         if msg == "":   # end of file
             return (msg, True)
         (dataLen, dataLenInv, msgSeq, fromAddr, toAddr, function) = \
             struct.unpack("<HHHLLH", msg[magicLen:])
         # read the data and checksum
-        msg += readBytes(inFile, dataLen + checksumLen, mode)
+        msg += readBytes(inFile, recFile, dataLen + checksumLen, mode)
         msg = msg[magicLen:]    # strip the magic number from the beginning
     else:
         # passive mode or rs485
         # read 1 byte at a time until the next magic number
         while msg[-magicLen:] != magic:
-            nextByte = readBytes(inFile, 1, mode)
+            nextByte = readBytes(inFile, recFile, 1, mode)
             if nextByte == "":  # end of file
                 eof = True
                 msg += magic  # append a magic number to end the loop
@@ -116,15 +115,10 @@ def readMsg(inFile, recFile, mode):
         msg = msg[:-magicLen]  # strip the magic number from the end
     if len(msg) > 0:  # don't log zero length messages
         logger.message("-->", dataInSeq, magic + msg, inFile.name)
-    if recFile:
-        recSeq += 1
-        logger.message("<--", recSeq, magic + msg, recFile.name)
-        recFile.write(magic + msg)  # include the magic number in the recorded file
-        recFile.flush()
     return (msg, eof)
 
 # return the specified number of bytes
-def readBytes(inFile, length, mode):
+def readBytes(inFile, recFile, length, mode):
     try:
         inBuf = inFile.read(length)
         if inBuf == "":  # end of file
@@ -133,6 +127,7 @@ def readBytes(inFile, length, mode):
                 while inBuf == "":
                     time.sleep(sleepInterval)
                     inBuf = inFile.read(length)
+        recordMsg(inBuf, recFile)
         return inBuf
     # treat exceptions as end of file
     except Exception as ex:
@@ -221,15 +216,17 @@ def formatMsg(msgSeq, fromAddr, toAddr, function, data="", encrypt=True):
 
 # send a message
 def sendMsg(dataFile, msg, recFile):
-    global dataOutSeq, recSeq
+    global dataOutSeq
     dataOutSeq += 1
     logger.message("<--", dataOutSeq, magic + msg, dataFile.name)
     dataFile.write(magic + msg)
     dataFile.flush()
+    recordMsg(magic + msg, recFile)
+
+# write a message to the record file
+def recordMsg(msg, recFile);
     if recFile:
-        recSeq += 1
-        logger.message("<--", recSeq, magic + msg, recFile.name)
-        recFile.write(magic + msg)
+        recFile.write(msg)
         recFile.flush()
 
 # crc calculation

--- a/test/rec/7f104920.rec
+++ b/test/rec/7f104920.rec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fdd069c7a8ecba17e31f4feeae33552e28cdc18045ebba55572183afaf76e44b
-size 368958
+oid sha256:f1591af2bc7c6fc2c54b41928c4637fca9eef70e29b8a94d990b7aa1e439ab28
+size 368954

--- a/test/rec/d-tamm-2.rec
+++ b/test/rec/d-tamm-2.rec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ff1974d378d79ff907e428a36bdc9639be4eb0f190c42a1f93df8841b840502
-size 726488
+oid sha256:35f0c5cb5df65f830e6312a22ec9175edbcec301c6dcb02c21d5f0d25cbba3a1
+size 726484

--- a/test/rec/d-tamm-20160809.rec
+++ b/test/rec/d-tamm-20160809.rec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e59a0afafa4c80ac1bac568c617da8c21a5803db786856b5fd321672458f4da5
-size 421151
+oid sha256:8a07afbd640b8145a8f4b2a45cd4d4ba759e939cf70fc45c71a353acd9abc717
+size 421147

--- a/test/rec/jbuehl-20171119000004.rec
+++ b/test/rec/jbuehl-20171119000004.rec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63bfa520c78ddcb7b137b18ac81acbf74965deb39e6992a70c8c1b2b9b8fe71b
-size 229112
+oid sha256:f183fd79d58079bc5ef1d68fa3ea484c64d68ddb194b94776cf02597be9aa623
+size 229108


### PR DESCRIPTION
This is intended to address issue #90.  Bytes are written to the record file as they are read from the input file before there is any attempt to parse messages which should result in an exact copy of the input data.  Sent messages are written to the record file as before.  Logging of messages written to the record file is removed.