### PR TITLE
Fix byte strings

### DIFF
--- a/se/data.py
+++ b/se/data.py
@@ -155,6 +155,11 @@ def parseDeviceData(data):
         elif seType == 0x0010:  # inverter data
             invDict[seId] = parseInvData(seId, invItems,
                                          data[dataPtr:dataPtr + devLen])
+            # Correct odd case where solaredge inverter sends Nan value in opposite byte order to all other float values
+            # ie solaredge sends b'\xff\xff\x7f\xff' which in little endian format unpacks as - 3.402... * 10 ** 38
+            # but b'\xff\x7f\xff\xff' unpacks as Nan, which is the "correct" value when this byte pattern is seen.
+            if invDict[seId]["PMax"] < -3 * 10**38:
+                invDict[seId]["PMax"] = float('nan')
             logDevice("inverter:     ", seType, seId, devLen, invDict[seId])
         elif seType == 0x0011:  # 3 phase inverter data
             invDict[seId] = parseInv3PhData(seId, inv3PhItems,

--- a/se/data.py
+++ b/se/data.py
@@ -8,6 +8,7 @@ import se.logutils
 import se.commands
 from se.dataparams import *
 from se.datadevices import ParseDevice, merge_update
+import codecs
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def parseData(function, data):
     else:
         # unknown function type
         logger.info("Unknown function 0x%04x", function)
-    return ''.join(x.encode('hex') for x in data)
+    return codecs.encode(data, 'hex').decode('ascii')
 
 def parseEnergyStats(data):
     (Eday, Emon, Eyear, Etot, Time1) = struct.unpack("<ffffL", data[0:20])

--- a/se/data.py
+++ b/se/data.py
@@ -158,8 +158,8 @@ def parseDeviceData(data):
             # Correct odd case where solaredge inverter sends Nan value in opposite byte order to all other float values
             # ie solaredge sends b'\xff\xff\x7f\xff' which in little endian format unpacks as - 3.402... * 10 ** 38
             # but b'\xff\x7f\xff\xff' unpacks as Nan, which is the "correct" value when this byte pattern is seen.
-            if invDict[seId]["PMax"] < -3 * 10**38:
-                invDict[seId]["PMax"] = float('nan')
+            if invDict[seId]["Pmax"] < -3 * 10**38:
+                invDict[seId]["Pmax"] = float('nan')
             logDevice("inverter:     ", seType, seId, devLen, invDict[seId])
         elif seType == 0x0011:  # 3 phase inverter data
             invDict[seId] = parseInv3PhData(seId, inv3PhItems,

--- a/se/datadevices.py
+++ b/se/datadevices.py
@@ -227,7 +227,7 @@ class ParseDevice(dict):
             # I suspect a legacy "bug" somewhere in the solaredge messages, but in the meantime just check the bytes
             # and fix it.
             elif paramInFmt == 'f' and (
-                    data[dataPtr:dataPtr + paramLen] == '\xff\xff\x7f\xff'):
+                    data[dataPtr:dataPtr + paramLen] == b'\xff\xff\x7f\xff'):
                 self[paramName] = float('nan')
             else:
                 self[paramName] = struct.unpack(

--- a/se/datadevices.py
+++ b/se/datadevices.py
@@ -232,6 +232,12 @@ class ParseDevice(dict):
             else:
                 self[paramName] = struct.unpack(
                     '<' + paramInFmt, data[dataPtr:dataPtr + paramLen])[0]
+                if 's' in paramInFmt:
+                    # Python3.x requires that we convert byte string to unicode string
+                    # if the value is to be used (later on) as a dictionary key for nested fields
+                    # Required for eg for battery Ids
+                    # Remove trailing 'null' character (ie 0x00) at the same time
+                    self[paramName] = self[paramName].decode('utf-8').strip('\x00')
 
             # Optionally format the field
             if outFormatFn == 'dateTime':

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.batteries_0x0030.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.batteries_0x0030.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7b22e9eea2e14faf1a56372174b934f8984a572e30ab8259f5639de639f5ae1
+size 767

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.batteries_0x0030.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.batteries_0x0030.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7b22e9eea2e14faf1a56372174b934f8984a572e30ab8259f5639de639f5ae1
-size 767
+oid sha256:7e87ddcab808be0205b53525e083a27c125ceb68f25f9e7b9e9fef77bde6a9d2
+size 764

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.inverters.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.inverters.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:beb37da0662797d2539b409ad46b60f472af830c2bc23db2b74791d2acbeb6ea
+size 410

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.inverters.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.inverters.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:beb37da0662797d2539b409ad46b60f472af830c2bc23db2b74791d2acbeb6ea
-size 410
+oid sha256:bd19b0404ababfb4177a63df8fd1e8b672efd7ae9e2db768cd766f599ee1f895
+size 407

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.meters_0x0022.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.meters_0x0022.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cef42acb45700a76837e28700d4da62ef54fc3bd59c787db129da78a5fa34e
+size 1958

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.meters_0x0022.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.meters_0x0022.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:95cef42acb45700a76837e28700d4da62ef54fc3bd59c787db129da78a5fa34e
-size 1958
+oid sha256:e05333cfa95f403d2ca9fedb410f8e118255f66a3b2117a2fdf76cedd95c1c94
+size 1947

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.optimizers.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.optimizers.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91b647c823e6d8aa8058c9148b838c4b91cf7d7773336e78a864f0d33289ce19
+size 3587

--- a/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.optimizers.csv
+++ b/test/csv/Geoff99.190801.1135.test/Geoff99.190801.1135.test.optimizers.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91b647c823e6d8aa8058c9148b838c4b91cf7d7773336e78a864f0d33289ce19
-size 3587
+oid sha256:cd1333773fde30545edfed271a9227dadc76d73e3976a31fc4687ca53d1b393c
+size 3545

--- a/test/json/Geoff99.190801.1135.test.json
+++ b/test/json/Geoff99.190801.1135.test.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d60da1708e13877f1c01d6020c538273441b3f828341a814d15e9f61aa7e90fa
+size 15983

--- a/test/json/Geoff99.190801.1135.test.json
+++ b/test/json/Geoff99.190801.1135.test.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d60da1708e13877f1c01d6020c538273441b3f828341a814d15e9f61aa7e90fa
+oid sha256:51582327cd2383f3b009e15cabefaa0199a699c0bdfef162c1e186dd1926df81
 size 15983

--- a/test/pcap/Geoff99.190801.1135.test.pcap
+++ b/test/pcap/Geoff99.190801.1135.test.pcap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc6608697f1916c8b40b194e609064230471dabc465a3b2e6bff25d7e5eab01d
+size 5894

--- a/test/rec/Geoff99.190801.1135.test.rec
+++ b/test/rec/Geoff99.190801.1135.test.rec
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc6608697f1916c8b40b194e609064230471dabc465a3b2e6bff25d7e5eab01d
+size 5894

--- a/test/rec/Geoff99.190801.1135.test.rec
+++ b/test/rec/Geoff99.190801.1135.test.rec
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc6608697f1916c8b40b194e609064230471dabc465a3b2e6bff25d7e5eab01d
-size 5894
+oid sha256:d79b9b4b22b5dc8e34c4ed4983a26f26c2c299a4a29915a542f2bd082a3b5dbd
+size 2822


### PR DESCRIPTION
Hi @jbuehl 
This pull request contains 3 small fixes motivated to the conversion from Python 2 to 3.x.

The first fixes the "trap", in **se/datadevices.py**, which detects and corrects Nan values which the solaredge inverter 0x0022 message incorrectly transmits in big endian rather than little endian order (relevant to the `PfromX` values).

The second implements a similar correction, in **se/data.py** for a similar issue with the `Pmax` value decoded by the inverter device.

The third, in **se/datadevices.py**, changes the `battery ID`, deciphered from the 0x0030 message type, from byte string to unicode string. This is necessary since the `battery ID` is later used as a dictionary key, and Python 3.x raises exceptions when the key is a byte string.

Regards
Geoff