### PR TITLE
FiX key extraction from RS485 interface

### DIFF
--- a/semonitor.py
+++ b/semonitor.py
@@ -172,7 +172,7 @@ def doCommands(args, mode, state, dataFile, recFile, outFile):
                           struct.pack(format, *tuple(params))), recFile)
         if mode.masterMode:  # send RS485 master command
             # grant control of the bus to the slave
-            masterGrant(dataFile, recFile, args.slaves[0])
+            masterGrant(state, dataFile, recFile, args.slaves[0])
         # wait for the response to the command
         (msg, eof) = se.msg.readMsg(dataFile, recFile, mode, state)
         (msgSeq, fromAddr, toAddr, response, data) = se.msg.parseMsg(msg)


### PR DESCRIPTION
It's currently broken:

root@firewall:/opt/solaredge# ./semonitor.py -m -t 4 -c 12,H239 -s 7315977D /dev/ttyUSB0
Traceback (most recent call last):
  File "./semonitor.py", line 268, in <module>
    doCommands(args, mode, state, dataFile, recFile, outFile)
  File "./semonitor.py", line 175, in doCommands
    masterGrant(dataFile, recFile, args.slaves[0])
TypeError: masterGrant() missing 1 required positional argument: 'slaveAddr'