### PR TITLE
Deprecation and sanity improvements

### DIFF
--- a/se/msg.py
+++ b/se/msg.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 sleepInterval = .1
 
 # Hard coded last0503.msg file. os module used to find full path to calling msg.py file, then removes the se part so it's essentially the root of solaredge (where semonitor.py lives)
-LAST0503FILE = os.path.dirname(os.path.realpath(__file__)).replace('/'+ __name__.split(".")[0], '') + "/last0503.msg"
+LAST0503FILE = os.path.dirname(os.path.realpath(__file__)).removesuffix(__name__.split(".")[0]) + "last0503.msg"
 
 class SECrypto:
     def __init__(self, key, msg0503):

--- a/semonitor.py
+++ b/semonitor.py
@@ -108,7 +108,7 @@ def processMsg(msg, args, mode, state, dataFile, recFile, outFile, keyStr, updat
                     (time.localtime().tm_hour - time.gmtime().tm_hour) * 60 * 60)
             elif function == se.commands.PROT_RESP_POLESTAR_MASTER_GRANT_ACK:  # RS485 master release
                 masterEvent.set()
-                se.logutils.setState(state, "masterEvent", masterEvent.isSet())
+                se.logutils.setState(state, "masterEvent", masterEvent.is_set())
             if replyFunction:
                 msg = se.msg.formatMsg(msgSeq, toAddr, fromAddr, replyFunction, replyData)
                 se.msg.sendMsg(dataFile, msg, recFile)
@@ -142,7 +142,7 @@ def masterGrant(state, dataFile, recFile, slaveAddr):
     def masterTimerExpire():
         logger.debug("RS485 master ack timeout")
         masterEvent.set()
-        se.logutils.setState(state, "masterEvent", masterEvent.isSet())
+        se.logutils.setState(state, "masterEvent", masterEvent.is_set())
         se.logutils.setState(state, "masterTimer", False)
 
     # start a timeout to release the bus if the slave doesn't respond
@@ -151,9 +151,9 @@ def masterGrant(state, dataFile, recFile, slaveAddr):
     se.logutils.setState(state, "masterTimer", True)
     # wait for slave to release the bus
     masterEvent.clear()
-    se.logutils.setState(state, "masterEvent", masterEvent.isSet())
+    se.logutils.setState(state, "masterEvent", masterEvent.is_set())
     masterEvent.wait()
-    se.logutils.setState(state, "masterEvent", masterEvent.isSet())
+    se.logutils.setState(state, "masterEvent", masterEvent.is_set())
     # cancel the timeout
     masterTimer.cancel()
     se.logutils.setState(state, "masterTimer", False)


### PR DESCRIPTION
Two small commits to improve quality of life.

Python 3.10 complains about `isSet` being deprecated, there's a drop-in replacement in the form of `is_set`.

The magic to store the hardcoded last0503 message fails if the path also contains `/se` already. We can do better here. Even better would have been to store this in `/tmp` or in `/var/lib/semonitor`, as storing it in the (distribution) source directory is a bit weird.